### PR TITLE
[issue-6] 유저, 매장 Soft Delete 완성하기

### DIFF
--- a/mega-coffee-api/src/main/kotlin/com/meloning/megaCoffee/domain/common/dto/CommonStoreResponse.kt
+++ b/mega-coffee-api/src/main/kotlin/com/meloning/megaCoffee/domain/common/dto/CommonStoreResponse.kt
@@ -8,7 +8,8 @@ data class CommonStoreResponse(
     val name: String,
     val type: StoreType,
     val address: AddressResponse,
-    val timeRange: TimeRangeResponse
+    val timeRange: TimeRangeResponse,
+    val deleted: Boolean
 ) {
     companion object {
         @JvmStatic
@@ -18,7 +19,8 @@ data class CommonStoreResponse(
                 name = name.value,
                 type = type,
                 address = AddressResponse.from(address),
-                timeRange = TimeRangeResponse.from(timeRange)
+                timeRange = TimeRangeResponse.from(timeRange),
+                deleted = deleted
             )
         }
     }

--- a/mega-coffee-api/src/main/kotlin/com/meloning/megaCoffee/domain/user/dto/ScrollUserResponse.kt
+++ b/mega-coffee-api/src/main/kotlin/com/meloning/megaCoffee/domain/user/dto/ScrollUserResponse.kt
@@ -16,7 +16,8 @@ data class ScrollUserResponse(
     data class StoreSimpleResponse(
         val id: Long,
         val name: String,
-        val type: StoreType
+        val type: StoreType,
+        val deleted: Boolean
     ) {
         companion object {
             @JvmStatic
@@ -24,7 +25,8 @@ data class ScrollUserResponse(
                 StoreSimpleResponse(
                     id = id!!,
                     name = name.value,
-                    type = type
+                    type = type,
+                    deleted = deleted
                 )
             }
         }

--- a/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/store/model/Store.kt
+++ b/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/store/model/Store.kt
@@ -18,8 +18,8 @@ data class Store(
     var createdAt: Instant? = null,
     var updatedAt: Instant? = null
 ) {
-    constructor(id: Long?, name: Name, type: StoreType) :
-        this(id, name, type, null, Address.DUMMY, TimeRange.DUMMY)
+    constructor(id: Long?, name: Name, type: StoreType, deleted: Boolean) :
+        this(id, name, type, null, Address.DUMMY, TimeRange.DUMMY, deleted)
 
     fun update(
         type: StoreType? = null,

--- a/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/store/model/Store.kt
+++ b/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/store/model/Store.kt
@@ -13,7 +13,7 @@ data class Store(
     var ownerId: Long?,
     var address: Address,
     var timeRange: TimeRange,
-    // 교육 프로그램 정보들
+    var deleted: Boolean = false,
     var educations: MutableList<StoreEducationRelation> = mutableListOf(),
     var createdAt: Instant? = null,
     var updatedAt: Instant? = null

--- a/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/store/repository/IStoreRepository.kt
+++ b/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/store/repository/IStoreRepository.kt
@@ -10,6 +10,7 @@ interface IStoreRepository {
     fun saveAll(stores: List<Store>): List<Store>
     fun update(store: Store)
 
+    fun findNotDeletedById(id: Long): Store?
     fun findById(id: Long): Store?
     fun findAll(storeId: Long?, page: Int, size: Int): InfiniteScrollType<Store>
 
@@ -17,6 +18,9 @@ interface IStoreRepository {
 
     fun deleteById(id: Long)
 }
+
+fun IStoreRepository.findNotDeletedByIdOrThrow(id: Long): Store =
+    this.findNotDeletedById(id) ?: throw NotFoundException("매장이 존재하지 않습니다.")
 
 fun IStoreRepository.findByIdOrThrow(id: Long): Store =
     this.findById(id) ?: throw NotFoundException("매장이 존재하지 않습니다.")

--- a/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/user/usecase/UserService.kt
+++ b/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/user/usecase/UserService.kt
@@ -8,6 +8,7 @@ import com.meloning.megaCoffee.core.domain.store.model.Store
 import com.meloning.megaCoffee.core.domain.store.model.StoreEducationRelation
 import com.meloning.megaCoffee.core.domain.store.repository.IStoreRepository
 import com.meloning.megaCoffee.core.domain.store.repository.findByIdOrThrow
+import com.meloning.megaCoffee.core.domain.store.repository.findNotDeletedByIdOrThrow
 import com.meloning.megaCoffee.core.domain.user.event.AppliedUserEducationAddressEvent
 import com.meloning.megaCoffee.core.domain.user.model.User
 import com.meloning.megaCoffee.core.domain.user.repository.IUserRepository
@@ -50,7 +51,7 @@ class UserService(
 
     fun registerEducationAddress(id: Long, command: RegisterEducationAddressCommand) {
         val user = userRepository.findDetailByIdOrThrow(id)
-        val store = storeRepository.findByIdOrThrow(user.storeId)
+        val store = storeRepository.findNotDeletedByIdOrThrow(user.storeId)
         val storeEducations = educationRepository.findAllByStoreId(store.id!!)
         store.update(storeEducations.map { StoreEducationRelation(store = store, educationId = it.id!!) })
 
@@ -105,7 +106,7 @@ class UserService(
             throw AlreadyExistException("이미 존재하는 유저입니다.")
         }
 
-        val store = storeRepository.findByIdOrThrow(command.storeId)
+        val store = storeRepository.findNotDeletedByIdOrThrow(command.storeId)
 
         val newUser = userRepository.save(command.toModel(store.id!!))
         if (newUser.isOwner() && store.ownerId.isNull()) {
@@ -119,7 +120,7 @@ class UserService(
         val user = userRepository.findByIdOrThrow(id)
 
         val store = command.storeId?.let {
-            storeRepository.findByIdOrThrow(it)
+            storeRepository.findNotDeletedByIdOrThrow(it)
         }
 
         with(command) {

--- a/mega-coffee-core/src/test/kotlin/com/meloning/megaCoffee/core/domain/user/service/UserServiceTest.kt
+++ b/mega-coffee-core/src/test/kotlin/com/meloning/megaCoffee/core/domain/user/service/UserServiceTest.kt
@@ -26,6 +26,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
+import org.springframework.context.ApplicationEventPublisher
 
 @ExtendWith(MockitoExtension::class)
 class UserServiceTest {
@@ -38,6 +39,9 @@ class UserServiceTest {
 
     @Mock
     private lateinit var educationRepository: IEducationRepository
+
+    @Mock
+    private lateinit var applicationEventPublisher: ApplicationEventPublisher
 
     @InjectMocks
     private lateinit var userService: UserService
@@ -82,7 +86,7 @@ class UserServiceTest {
         )
 
         whenever(userRepository.existsByNameAndEmail(mockName, mockEmail)).thenReturn(false)
-        whenever(storeRepository.findById(1)).thenReturn(mockStore)
+        whenever(storeRepository.findNotDeletedById(1)).thenReturn(mockStore)
         whenever(userRepository.save(any())).thenReturn(mockUser)
 
         // when
@@ -181,7 +185,7 @@ class UserServiceTest {
         )
 
         whenever(userRepository.findById(any())).thenReturn(mockUser)
-        whenever(storeRepository.findById(any())).thenReturn(mockStore)
+        whenever(storeRepository.findNotDeletedById(any())).thenReturn(mockStore)
 
         // when
         val updatedUser = userService.update(1, command)

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/education/repository/CustomEducationJpaRepositoryImpl.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/education/repository/CustomEducationJpaRepositoryImpl.kt
@@ -6,11 +6,13 @@ import com.meloning.megaCoffee.infra.database.mysql.domain.education.entity.QEdu
 import com.meloning.megaCoffee.infra.database.mysql.domain.education.entity.QEducationEntity
 import com.meloning.megaCoffee.infra.database.mysql.domain.store.entity.QStoreEducationRelationEntity
 import com.meloning.megaCoffee.infra.database.mysql.domain.user.entity.QUserEducationAddressRelationEntity
+import com.meloning.megaCoffee.infra.database.mysql.domain.user.entity.QUserEntity
 import com.querydsl.jpa.impl.JPAQueryFactory
 
 class CustomEducationJpaRepositoryImpl(
     private val jpaQueryFactory: JPAQueryFactory
 ) : CustomEducationJpaRepository {
+    private val qUserEntity = QUserEntity.userEntity
     private val qEducationEntity = QEducationEntity.educationEntity
     private val qEducationAddressEntity = QEducationAddressEntity.educationAddressEntity
     private val qStoreEducationRelationEntity = QStoreEducationRelationEntity.storeEducationRelationEntity
@@ -41,7 +43,11 @@ class CustomEducationJpaRepositoryImpl(
         val userEducationAddresses = jpaQueryFactory.selectFrom(qEducationAddressEntity)
             .join(qUserEducationAddressRelationEntity)
             .on(qEducationAddressEntity.id.eq(qUserEducationAddressRelationEntity.educationAddressId))
-            .where(qUserEducationAddressRelationEntity.user.id.eq(userId))
+            .innerJoin(qUserEducationAddressRelationEntity.user, qUserEntity)
+            .where(
+                qUserEntity.deleted.isFalse,
+                qUserEducationAddressRelationEntity.user.id.eq(userId)
+            )
             .fetch()
 
         return educations to userEducationAddresses

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/store/entity/StoreEntity.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/store/entity/StoreEntity.kt
@@ -6,8 +6,10 @@ import com.meloning.megaCoffee.infra.database.mysql.domain.common.AddressVO
 import com.meloning.megaCoffee.infra.database.mysql.domain.common.BaseTimeEntity
 import com.meloning.megaCoffee.infra.database.mysql.domain.common.NameVO
 import com.meloning.megaCoffee.infra.database.mysql.domain.common.TimeRangeVO
+import org.hibernate.annotations.ColumnDefault
 import org.hibernate.annotations.DynamicInsert
 import org.hibernate.annotations.DynamicUpdate
+import org.hibernate.annotations.SQLDelete
 import org.hibernate.proxy.HibernateProxy
 import javax.persistence.AttributeOverride
 import javax.persistence.AttributeOverrides
@@ -27,15 +29,17 @@ import javax.persistence.Table
 @Table(name = "store")
 @DynamicInsert
 @DynamicUpdate
+@SQLDelete(sql = "update store set is_deleted = true where id = ?")
 class StoreEntity : BaseTimeEntity {
 
-    constructor(id: Long?, name: NameVO, type: StoreType, ownerId: Long?, address: AddressVO, timeRange: TimeRangeVO) : super() {
+    constructor(id: Long?, name: NameVO, type: StoreType, ownerId: Long?, address: AddressVO, timeRange: TimeRangeVO, deleted: Boolean) : super() {
         this.id = id
         this.name = name
         this.type = type
         this.ownerId = ownerId
         this.address = address
         this.timeRange = timeRange
+        this.deleted = deleted
     }
 
     @Id
@@ -70,6 +74,11 @@ class StoreEntity : BaseTimeEntity {
     var educations: MutableList<StoreEducationRelationEntity> = mutableListOf()
         protected set
 
+    @Column(name = "is_deleted", nullable = false)
+    @ColumnDefault(value = "0")
+    var deleted: Boolean = false
+        protected set
+
     fun update(educations: MutableList<StoreEducationRelationEntity>) {
         this.educations = educations
     }
@@ -94,7 +103,8 @@ class StoreEntity : BaseTimeEntity {
                 type = type,
                 ownerId = ownerId,
                 address = AddressVO.from(address),
-                timeRange = TimeRangeVO.from(timeRange)
+                timeRange = TimeRangeVO.from(timeRange),
+                deleted = deleted
             )
         }
     }

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/store/entity/StoreEntity.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/store/entity/StoreEntity.kt
@@ -90,6 +90,7 @@ class StoreEntity : BaseTimeEntity {
         ownerId = ownerId,
         address = address.toModel(),
         timeRange = timeRange.toModel(),
+        deleted = deleted,
         createdAt = createdAt,
         updatedAt = updatedAt
     )

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/store/repository/CustomStoreJpaRepositoryImpl.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/store/repository/CustomStoreJpaRepositoryImpl.kt
@@ -17,6 +17,7 @@ class CustomStoreJpaRepositoryImpl(
         val pageRequest = PageRequest.of(page, size)
         val result = jpaQueryFactory.selectFrom(qStoreEntity)
             .where(
+                qStoreEntity.deleted.isFalse,
                 gtStoreLastId(storeId)
             )
             .orderBy(qStoreEntity.id.asc())

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/store/repository/StoreJpaRepository.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/store/repository/StoreJpaRepository.kt
@@ -5,5 +5,6 @@ import com.meloning.megaCoffee.infra.database.mysql.domain.store.entity.StoreEnt
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface StoreJpaRepository : JpaRepository<StoreEntity, Long>, CustomStoreJpaRepository {
-    fun existsByName(name: NameVO): Boolean
+    fun existsByNameAndDeletedIsFalse(name: NameVO): Boolean
+    fun findByIdAndDeletedIsFalse(id: Long): StoreEntity?
 }

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/store/repository/StoreRepositoryImpl.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/store/repository/StoreRepositoryImpl.kt
@@ -7,7 +7,6 @@ import com.meloning.megaCoffee.core.util.InfiniteScrollType
 import com.meloning.megaCoffee.infra.database.mysql.domain.common.NameVO
 import com.meloning.megaCoffee.infra.database.mysql.domain.store.entity.StoreEducationRelationEntity
 import com.meloning.megaCoffee.infra.database.mysql.domain.store.entity.StoreEntity
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -38,11 +37,11 @@ class StoreRepositoryImpl(
     }
 
     override fun findById(id: Long): Store? {
-        return storeJpaRepository.findByIdOrNull(id)?.toModel()
+        return storeJpaRepository.findByIdAndDeletedIsFalse(id)?.toModel()
     }
 
     override fun existsByName(name: Name): Boolean {
-        return storeJpaRepository.existsByName(NameVO.from(name))
+        return storeJpaRepository.existsByNameAndDeletedIsFalse(NameVO.from(name))
     }
 
     override fun deleteById(id: Long) {

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/store/repository/StoreRepositoryImpl.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/store/repository/StoreRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.meloning.megaCoffee.core.util.InfiniteScrollType
 import com.meloning.megaCoffee.infra.database.mysql.domain.common.NameVO
 import com.meloning.megaCoffee.infra.database.mysql.domain.store.entity.StoreEducationRelationEntity
 import com.meloning.megaCoffee.infra.database.mysql.domain.store.entity.StoreEntity
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -36,8 +37,12 @@ class StoreRepositoryImpl(
         return content.map { it.toModel() } to hasNext
     }
 
-    override fun findById(id: Long): Store? {
+    override fun findNotDeletedById(id: Long): Store? {
         return storeJpaRepository.findByIdAndDeletedIsFalse(id)?.toModel()
+    }
+
+    override fun findById(id: Long): Store? {
+        return storeJpaRepository.findByIdOrNull(id)?.toModel()
     }
 
     override fun existsByName(name: Name): Boolean {

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/repository/CustomUserJpaRepositoryImpl.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/repository/CustomUserJpaRepositoryImpl.kt
@@ -31,7 +31,8 @@ class CustomUserJpaRepositoryImpl(
                 store = QUserShortRow_UserStoreRow(
                     id = qStoreEntity.id,
                     name = qStoreEntity.name,
-                    type = qStoreEntity.type
+                    type = qStoreEntity.type,
+                    deleted = qStoreEntity.deleted
                 )
             )
         )

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/repository/CustomUserJpaRepositoryImpl.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/repository/CustomUserJpaRepositoryImpl.kt
@@ -38,6 +38,7 @@ class CustomUserJpaRepositoryImpl(
             .from(qUserEntity)
             .join(qStoreEntity).on(qUserEntity.storeId.eq(qStoreEntity.id))
             .where(
+                qUserEntity.deleted.isFalse,
                 gtUserLastId(command.userId),
                 filterStoreId(command.storeId),
                 filterEmployeeType(command.employeeType),

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/repository/UserJpaRepository.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/repository/UserJpaRepository.kt
@@ -5,5 +5,6 @@ import com.meloning.megaCoffee.infra.database.mysql.domain.user.entity.UserEntit
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserJpaRepository : JpaRepository<UserEntity, Long>, CustomUserJpaRepository {
-    fun existsByNameAndEmail(name: NameVO, email: String): Boolean
+    fun existsByNameAndEmailAndDeletedIsFalse(name: NameVO, email: String): Boolean
+    fun findByIdAndDeletedIsFalse(id: Long): UserEntity?
 }

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/repository/UserRepositoryImpl.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/repository/UserRepositoryImpl.kt
@@ -10,7 +10,6 @@ import com.meloning.megaCoffee.infra.database.mysql.domain.common.NameVO
 import com.meloning.megaCoffee.infra.database.mysql.domain.user.entity.UserEducationAddressRelationEntity
 import com.meloning.megaCoffee.infra.database.mysql.domain.user.entity.UserEntity
 import org.hibernate.Hibernate
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -39,11 +38,11 @@ class UserRepositoryImpl(
     }
 
     override fun findById(id: Long): User? {
-        return userJpaRepository.findByIdOrNull(id)?.toModel()
+        return userJpaRepository.findByIdAndDeletedIsFalse(id)?.toModel()
     }
 
     override fun existsByNameAndEmail(name: Name, email: String): Boolean {
-        return userJpaRepository.existsByNameAndEmail(NameVO.from(name), email)
+        return userJpaRepository.existsByNameAndEmailAndDeletedIsFalse(NameVO.from(name), email)
     }
 
     override fun deleteById(id: Long) {
@@ -51,7 +50,7 @@ class UserRepositoryImpl(
     }
 
     override fun findDetailById(id: Long): User? {
-        val userEntity = userJpaRepository.findByIdOrNull(id)
+        val userEntity = userJpaRepository.findByIdAndDeletedIsFalse(id)
         userEntity?.educationAddressRelations?.forEach {
             Hibernate.initialize(it)
         }

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/repository/dto/UserShortRow.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/repository/dto/UserShortRow.kt
@@ -23,12 +23,14 @@ constructor(
     constructor(
         val id: Long,
         val name: NameVO,
-        val type: StoreType
+        val type: StoreType,
+        val deleted: Boolean,
     ) {
         fun toModel() = Store(
             id = id,
             name = name.toModel(),
-            type = type
+            type = type,
+            deleted = deleted
         )
     }
 

--- a/mega-coffee-infra/database/mysql/src/test/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/store/entity/StoreEntityFixture.kt
+++ b/mega-coffee-infra/database/mysql/src/test/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/store/entity/StoreEntityFixture.kt
@@ -8,7 +8,7 @@ import java.time.LocalTime
 
 object StoreEntityFixture {
     internal fun generateTestStoreEntities(): List<StoreEntity> = listOf(
-        StoreEntity(1, NameVO("서대문점"), StoreType.FRANCHISE, 1, AddressVO("서울", "서대문", "123"), TimeRangeVO(LocalTime.of(8, 0), LocalTime.of(23, 0))),
-        StoreEntity(2, NameVO("신림점"), StoreType.COMPANY_OWNED, 5, AddressVO("서울", "신림", "123"), TimeRangeVO(LocalTime.of(10, 0), LocalTime.of(21, 0))),
+        StoreEntity(1, NameVO("서대문점"), StoreType.FRANCHISE, 1, AddressVO("서울", "서대문", "123"), TimeRangeVO(LocalTime.of(8, 0), LocalTime.of(23, 0)), false),
+        StoreEntity(2, NameVO("신림점"), StoreType.COMPANY_OWNED, 5, AddressVO("서울", "신림", "123"), TimeRangeVO(LocalTime.of(10, 0), LocalTime.of(21, 0)), false),
     )
 }


### PR DESCRIPTION
Related: #4 

- 삭제된 유저가 조회되는 버그 해결
- 매장 삭제 Soft Delete 적용
- 매장 삭제시 유저 상세 및 유저 스크롤 리스트 API에서는 보여지도록 변경
  - 유저 상세 및 스크롤 API의 응답 구조에서 매장 deleted 필드 추가
