### PR TITLE
[issue-5] 유저의 교육장소 등록 API 동시성 발생에 따른 문제 해결

### DIFF
--- a/clients/java-email/src/main/kotlin/com/meloning/megaCoffee/clients/javaEmail/service/EmailSender.kt
+++ b/clients/java-email/src/main/kotlin/com/meloning/megaCoffee/clients/javaEmail/service/EmailSender.kt
@@ -16,7 +16,7 @@ class EmailSender(
     fun send(emailFormDto: EmailFormDto) {
         try {
             val message = javaMailSender.createMimeMessage()
-            val helper = MimeMessageHelper(
+            MimeMessageHelper(
                 message,
                 MimeMessageHelper.MULTIPART_MODE_MIXED_RELATED,
                 StandardCharsets.UTF_8.name()

--- a/mega-coffee-api/src/main/kotlin/com/meloning/megaCoffee/domain/user/UserApiController.kt
+++ b/mega-coffee-api/src/main/kotlin/com/meloning/megaCoffee/domain/user/UserApiController.kt
@@ -1,5 +1,6 @@
 package com.meloning.megaCoffee.domain.user
 
+import com.meloning.megaCoffee.core.domain.user.usecase.RegisterEducationAddressFacadeService
 import com.meloning.megaCoffee.core.domain.user.usecase.UserService
 import com.meloning.megaCoffee.domain.user.dto.CreateUserRequest
 import com.meloning.megaCoffee.domain.user.dto.CreateUserResponse
@@ -27,7 +28,8 @@ import javax.validation.Valid
 @RestController
 @RequestMapping("/api/v1")
 class UserApiController(
-    private val userService: UserService
+    private val userService: UserService,
+    private val registerEducationAddressFacadeService: RegisterEducationAddressFacadeService
 ) {
 
     @GetMapping("/users/scroll")
@@ -59,7 +61,7 @@ class UserApiController(
         @PathVariable id: Long,
         @Valid @RequestBody request: RegisterEducationAddressRequest
     ): ResponseEntity<Void> {
-        userService.registerEducationAddress(id, request.toCommand())
+        registerEducationAddressFacadeService.execute(id, request.toCommand())
         return ResponseEntity.accepted().build()
     }
 

--- a/mega-coffee-api/src/main/resources/application-logging.yml
+++ b/mega-coffee-api/src/main/resources/application-logging.yml
@@ -16,4 +16,14 @@ logging:
     root: INFO
     org.springframework.web: DEBUG
     org.springframework.boot.autoconfigure: INFO
+    # [JPA:SQL]
+    org.hibernate.sql: INFO
     org.hibernate.type.descriptor.sql: TRACE
+    # [JPA:Transaction]
+    org.springframework.transaction: DEBUG
+    org.hibernate.engine.transaction: TRACE
+    # [JPA:DBCP]
+    com.zaxxer.hikari: TRACE
+    com.zaxxer.hikari.HikariConfig: DEBUG
+    # [Retry]
+    org.springframework.retry.support.RetryTemplate: DEBUG

--- a/mega-coffee-api/src/test/kotlin/com/meloning/megaCoffee/domain/education/EducationApiTest.kt
+++ b/mega-coffee-api/src/test/kotlin/com/meloning/megaCoffee/domain/education/EducationApiTest.kt
@@ -89,7 +89,7 @@ class EducationApiTest : ApiTest() {
 
         val education = Education(educationId, Name("테스트 교육"), "어쩌구", mutableListOf(EmployeeType.MANAGER, EmployeeType.PART_TIME))
         val createdEducation = educationRepository.save(education)
-        val educationAddress = EducationAddress(null, createdEducation, Address.DUMMY, 3, LocalDate.now(), TimeRange.DUMMY)
+        val educationAddress = EducationAddress(null, createdEducation, Address.DUMMY, 3, 0, LocalDate.now(), TimeRange.DUMMY)
         educationRepository.update(createdEducation.apply { update(EducationAddresses(mutableListOf(educationAddress))) })
 
         // when

--- a/mega-coffee-api/src/test/kotlin/com/meloning/megaCoffee/domain/store/StoreApiTest.kt
+++ b/mega-coffee-api/src/test/kotlin/com/meloning/megaCoffee/domain/store/StoreApiTest.kt
@@ -42,7 +42,7 @@ class StoreApiTest : ApiTest() {
     @BeforeEach
     fun init() {
         // TODO: Refactoring Target
-        val stores = storeRepository.saveAll(
+        storeRepository.saveAll(
             listOf(
                 Store(1, Name("메가커피 서대문역점"), StoreType.FRANCHISE, false),
                 Store(2, Name("메가커피 구로점"), StoreType.COMPANY_OWNED, true),

--- a/mega-coffee-api/src/test/kotlin/com/meloning/megaCoffee/domain/store/StoreApiTest.kt
+++ b/mega-coffee-api/src/test/kotlin/com/meloning/megaCoffee/domain/store/StoreApiTest.kt
@@ -66,7 +66,7 @@ class StoreApiTest : ApiTest() {
         )
         val education = Education(1, Name("테스트 교육"), "어쩌구", mutableListOf(EmployeeType.MANAGER, EmployeeType.PART_TIME))
         val createdEducation = educationRepository.save(education)
-        val educationAddress = EducationAddress(null, createdEducation, Address.DUMMY, 3, LocalDate.now(), TimeRange.DUMMY)
+        val educationAddress = EducationAddress(null, createdEducation, Address.DUMMY, 3, 0, LocalDate.now(), TimeRange.DUMMY)
         educationRepository.update(createdEducation.apply { update(EducationAddresses(mutableListOf(educationAddress))) })
     }
 

--- a/mega-coffee-api/src/test/kotlin/com/meloning/megaCoffee/domain/user/UserApiTest.kt
+++ b/mega-coffee-api/src/test/kotlin/com/meloning/megaCoffee/domain/user/UserApiTest.kt
@@ -62,7 +62,7 @@ class UserApiTest : ApiTest() {
         )
         val education = Education(1, Name("테스트 교육"), "어쩌구", mutableListOf(EmployeeType.MANAGER, EmployeeType.PART_TIME))
         val createdEducation = educationRepository.save(education)
-        val educationAddress = EducationAddress(null, createdEducation, Address.DUMMY, 3, LocalDate.now(), TimeRange.DUMMY)
+        val educationAddress = EducationAddress(null, createdEducation, Address.DUMMY, 3, 0, LocalDate.now(), TimeRange.DUMMY)
         educationRepository.update(createdEducation.apply { update(EducationAddresses(mutableListOf(educationAddress))) })
         storeRepository.update(stores.first().apply { addEducation(createdEducation.id!!) })
     }

--- a/mega-coffee-api/src/test/kotlin/com/meloning/megaCoffee/domain/user/UserConcurrencyTest.kt
+++ b/mega-coffee-api/src/test/kotlin/com/meloning/megaCoffee/domain/user/UserConcurrencyTest.kt
@@ -1,0 +1,88 @@
+package com.meloning.megaCoffee.domain.user
+
+import com.meloning.megaCoffee.ApiTest
+import com.meloning.megaCoffee.core.domain.common.Address
+import com.meloning.megaCoffee.core.domain.common.Name
+import com.meloning.megaCoffee.core.domain.common.TimeRange
+import com.meloning.megaCoffee.core.domain.education.model.Education
+import com.meloning.megaCoffee.core.domain.education.model.EducationAddress
+import com.meloning.megaCoffee.core.domain.education.model.EducationAddresses
+import com.meloning.megaCoffee.core.domain.education.repository.IEducationRepository
+import com.meloning.megaCoffee.core.domain.store.model.Store
+import com.meloning.megaCoffee.core.domain.store.model.StoreType
+import com.meloning.megaCoffee.core.domain.store.repository.IStoreRepository
+import com.meloning.megaCoffee.core.domain.user.model.EmployeeType
+import com.meloning.megaCoffee.core.domain.user.model.User
+import com.meloning.megaCoffee.core.domain.user.model.WorkTimeType
+import com.meloning.megaCoffee.core.domain.user.repository.IUserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.SoftAssertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+class UserConcurrencyTest : ApiTest() {
+
+    private lateinit var executorService: ExecutorService
+    private lateinit var latch: CountDownLatch
+
+    @Autowired
+    private lateinit var storeRepository: IStoreRepository
+
+    @Autowired
+    private lateinit var userRepository: IUserRepository
+
+    @Autowired
+    private lateinit var educationRepository: IEducationRepository
+
+    @BeforeEach
+    fun init() {
+        executorService = Executors.newFixedThreadPool(THREAD_SIZE)
+        latch = CountDownLatch(THREAD_SIZE)
+
+        val targetTypes = mutableListOf(EmployeeType.MANAGER, EmployeeType.PART_TIME)
+        val education = educationRepository.save(
+            Education(null, Name("다양한 커피 음료 및 레시피에 대해 학습하는 교육 프로그램입니다."), "커피 음료와 레시피 교육", targetTypes)
+        )
+        val educationAddresses = mutableListOf(
+            EducationAddress(null, education, Address("부산", "해운대구 해운대로 111번길", "48100"), 1, 0, LocalDate.of(2023, 12, 31), TimeRange(LocalTime.of(19, 0), LocalTime.of(20, 0)))
+        )
+        educationRepository.update(education.apply { update(EducationAddresses(educationAddresses)) })
+
+        val store = storeRepository.save(Store(null, Name("메가커피 서대문점"), StoreType.FRANCHISE, false))
+        userRepository.save(User(null, Name("메로닝"), EmployeeType.PART_TIME, WorkTimeType.WEEKEND, store.id!!))
+        storeRepository.update(store.apply { addEducation(education.id!!) })
+    }
+
+    @Test
+    @DisplayName("교육 신청 동시성 테스트")
+    fun test() {
+        val userId = 1L
+        val request = UserSteps.교육장소_등록()
+
+        for (i in 0..THREAD_SIZE) {
+            executorService.execute {
+                UserSteps.교육장소_등록_요청(userId, request)
+                latch.countDown()
+            }
+        }
+        latch.await()
+
+        val detailResponse = UserSteps.상세_요청(userId)
+        SoftAssertions.assertSoftly {
+            it.run {
+                assertThat(detailResponse.jsonPath().getList<Any>("educations").size).isEqualTo(1)
+            }
+        }
+    }
+
+    companion object {
+        const val THREAD_SIZE = 2
+    }
+}

--- a/mega-coffee-api/src/test/resources/application-logging.yml
+++ b/mega-coffee-api/src/test/resources/application-logging.yml
@@ -1,0 +1,30 @@
+# 공통
+logging:
+  level:
+    root: INFO
+    org.springframework.web: INFO
+    org.springframework.boot.autoconfigure: INFO
+
+---
+spring:
+  config:
+    activate:
+      on-profile: logging-local
+
+logging:
+  level:
+    root: INFO
+    org.springframework.web: DEBUG
+    org.springframework.boot.autoconfigure: INFO
+    # [JPA:SQL]
+    org.hibernate.sql: INFO
+    org.hibernate.type.descriptor.sql: TRACE
+    # [JPA:Transaction]
+    org.springframework.transaction: DEBUG
+    org.hibernate.engine.transaction: TRACE
+    # [JPA:DBCP]
+    com.zaxxer.hikari: TRACE
+    com.zaxxer.hikari.HikariConfig: DEBUG
+    # [Retry]
+    org.springframework.retry.support.RetryTemplate: DEBUG
+  config: classpath:logback-test.xml

--- a/mega-coffee-api/src/test/resources/application.yml
+++ b/mega-coffee-api/src/test/resources/application.yml
@@ -2,6 +2,7 @@ spring:
   profiles:
     include:
       - mysql
+      - logging
     group:
-      test: db-local
+      test: db-local, logging-local
     active: test

--- a/mega-coffee-api/src/test/resources/logback-test.xml
+++ b/mega-coffee-api/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <!-- The following logger can be used for containers logs since 1.18.0 -->
+    <logger name="tc" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>

--- a/mega-coffee-common/src/main/kotlin/com/meloning/megaCoffee/common/error/exception/InternalServerErrorException.kt
+++ b/mega-coffee-common/src/main/kotlin/com/meloning/megaCoffee/common/error/exception/InternalServerErrorException.kt
@@ -1,0 +1,9 @@
+package com.meloning.megaCoffee.common.error.exception
+
+class InternalServerErrorException : ApplicationException {
+    override val code: String = "internal_server_error"
+    override val statusCode: Int = 500
+
+    constructor(message: String) : super(message)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+}

--- a/mega-coffee-common/src/main/kotlin/com/meloning/megaCoffee/common/error/exception/RetryFailedException.kt
+++ b/mega-coffee-common/src/main/kotlin/com/meloning/megaCoffee/common/error/exception/RetryFailedException.kt
@@ -1,0 +1,9 @@
+package com.meloning.megaCoffee.common.error.exception
+
+class RetryFailedException : ApplicationException {
+    override val code: String = "retry_failed"
+    override val statusCode: Int = 500
+
+    constructor(message: String) : super(message)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+}

--- a/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/education/model/EducationAddress.kt
+++ b/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/education/model/EducationAddress.kt
@@ -11,6 +11,7 @@ data class EducationAddress(
     var education: Education,
     var address: Address,
     var maxParticipant: Int,
+    var currentParticipant: Int = 0,
     var date: LocalDate,
     var timeRange: TimeRange,
     var createdAt: Instant? = null,
@@ -26,14 +27,18 @@ data class EducationAddress(
             isSameDateTimeSlots(other)
     }
 
-    private fun isMaxParticipantCountExceeded(currentParticipantCount: Int): Boolean {
-        return currentParticipantCount == maxParticipant
+    private fun isParticipantExceeded(): Boolean {
+        return currentParticipant == maxParticipant
     }
 
-    fun validateMaxParticipantExceeded(currentParticipantCount: Int) {
-        if (isMaxParticipantCountExceeded(currentParticipantCount)) {
+    fun validateMaxParticipantExceeded() {
+        if (isParticipantExceeded()) {
             throw AlreadyFullException("선택한 교육장소($id)의 수강인원($maxParticipant)이 가득찼습니다.")
         }
+    }
+
+    fun increaseCurrentParticipant() {
+        this.currentParticipant++
     }
 
     override fun equals(other: Any?): Boolean {

--- a/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/education/model/EducationAddresses.kt
+++ b/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/education/model/EducationAddresses.kt
@@ -50,6 +50,10 @@ class EducationAddresses(
         }
     }
 
+    fun findAndIncreaseCurrentParticipant(id: Long) {
+        _value.find { it.id!! == id }?.increaseCurrentParticipant()
+    }
+
     fun filterByContainedIds(educationAddressIds: List<Long>): List<EducationAddress> {
         return _value.filter { educationAddressIds.contains(it.id) }
     }

--- a/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/education/repository/IEducationRepository.kt
+++ b/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/education/repository/IEducationRepository.kt
@@ -13,7 +13,6 @@ interface IEducationRepository {
     fun findDetailById(id: Long): Education?
     fun findAllByStoreIdAndUserId(storeId: Long, userId: Long): List<Education>
     fun findAllByStoreId(storeId: Long): List<Education>
-    fun countByEducationAddressId(educationAddressId: Long): Int
 
     fun existsByName(name: Name): Boolean
 

--- a/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/user/model/User.kt
+++ b/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/user/model/User.kt
@@ -17,14 +17,14 @@ data class User(
     var workTimeType: WorkTimeType,
     var storeId: Long,
     var deleted: Boolean = false,
-    var educationAddressRelations: MutableList<UserEducationAddressRelation> = mutableListOf(),
+    var educationAddressRelations: MutableSet<UserEducationAddressRelation> = mutableSetOf(),
     var createdAt: Instant? = null,
     var updatedAt: Instant? = null
 ) {
     constructor(id: Long?, name: Name, employeeType: EmployeeType, workTimeType: WorkTimeType, storeId: Long) :
         this(id, Constant.EMPTY, name, Address.DUMMY, employeeType, PhoneNumber.DUMMY, workTimeType, storeId)
 
-    fun update(educationAddressRelations: MutableList<UserEducationAddressRelation>) {
+    fun update(educationAddressRelations: MutableSet<UserEducationAddressRelation>) {
         this.educationAddressRelations = educationAddressRelations
     }
 

--- a/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/user/model/UserEducationAddressRelation.kt
+++ b/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/user/model/UserEducationAddressRelation.kt
@@ -7,4 +7,22 @@ data class UserEducationAddressRelation(
     val user: User,
     val educationAddressId: Long,
     var createdAt: Instant? = null
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as UserEducationAddressRelation
+
+        if (user != other.user) return false
+        if (educationAddressId != other.educationAddressId) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = user.hashCode()
+        result = 31 * result + educationAddressId.hashCode()
+        return result
+    }
+}

--- a/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/user/usecase/RegisterEducationAddressFacadeService.kt
+++ b/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/user/usecase/RegisterEducationAddressFacadeService.kt
@@ -1,0 +1,7 @@
+package com.meloning.megaCoffee.core.domain.user.usecase
+
+import com.meloning.megaCoffee.core.domain.user.usecase.command.RegisterEducationAddressCommand
+
+interface RegisterEducationAddressFacadeService {
+    fun execute(id: Long, command: RegisterEducationAddressCommand)
+}

--- a/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/user/usecase/UserService.kt
+++ b/mega-coffee-core/src/main/kotlin/com/meloning/megaCoffee/core/domain/user/usecase/UserService.kt
@@ -77,14 +77,17 @@ class UserService(
 
         // 선택한 교육 장소의 수강인원이 가득차 있는지
         selectedEducationAddresses.forEach {
-            it.validateMaxParticipantExceeded(educationRepository.countByEducationAddressId(it.id!!))
+            it.validateMaxParticipantExceeded()
         }
 
         command.educationAddressIds.forEach {
+            // TODO: Refactoring Target
             user.addEducationAddress(it)
+            educationAddresses.findAndIncreaseCurrentParticipant(it)
         }
 
         userRepository.update(user)
+        educationRepository.update(education)
 
         // 교육 신청한 직원은 신청 완료에 대한 알림을 받을 수 있다.
         selectedEducationAddresses.forEach {

--- a/mega-coffee-core/src/test/kotlin/com/meloning/megaCoffee/core/domain/education/model/EducationAddressTest.kt
+++ b/mega-coffee-core/src/test/kotlin/com/meloning/megaCoffee/core/domain/education/model/EducationAddressTest.kt
@@ -104,6 +104,7 @@ class EducationAddressTest {
             id = 1,
             education = education,
             address = Address("서울", "관악구", "123"),
+            currentParticipant = 23,
             maxParticipant = 23,
             date = LocalDate.now(),
             timeRange = TimeRange(LocalTime.of(10, 0), LocalTime.of(20, 0))
@@ -111,7 +112,7 @@ class EducationAddressTest {
 
         // when, then
         Assertions.assertThatThrownBy {
-            educationAddress.validateMaxParticipantExceeded(23)
+            educationAddress.validateMaxParticipantExceeded()
         }.isInstanceOf(AlreadyFullException::class.java)
             .hasMessage("선택한 교육장소(1)의 수강인원(23)이 가득찼습니다.")
     }

--- a/mega-coffee-core/src/test/kotlin/com/meloning/megaCoffee/core/domain/education/model/EducationAddressesTest.kt
+++ b/mega-coffee-core/src/test/kotlin/com/meloning/megaCoffee/core/domain/education/model/EducationAddressesTest.kt
@@ -29,11 +29,11 @@ class EducationAddressesTest {
         )
 
         val educationAddressList = mutableListOf(
-            EducationAddress(1, mockEducation, Address("서울", "관악구", "123"), 13, LocalDate.of(2023, 1, 27), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
-            EducationAddress(2, mockEducation, Address("서울", "강서구", "123"), 15, LocalDate.of(2023, 4, 19), TimeRange(LocalTime.of(13, 0), LocalTime.of(17, 0))),
-            EducationAddress(3, mockEducation, Address("서울", "강남구", "123"), 4, LocalDate.now(), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
-            EducationAddress(4, mockEducation, Address("서울", "구로구", "123"), 9, LocalDate.now(), TimeRange(LocalTime.of(12, 0), LocalTime.of(18, 0))),
-            EducationAddress(5, mockEducation, Address("서울", "송파구", "123"), 21, LocalDate.of(2023, 12, 24), TimeRange(LocalTime.of(1, 0), LocalTime.of(23, 0))),
+            EducationAddress(1, mockEducation, Address("서울", "관악구", "123"), 13, 0, LocalDate.of(2023, 1, 27), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
+            EducationAddress(2, mockEducation, Address("서울", "강서구", "123"), 15, 0, LocalDate.of(2023, 4, 19), TimeRange(LocalTime.of(13, 0), LocalTime.of(17, 0))),
+            EducationAddress(3, mockEducation, Address("서울", "강남구", "123"), 4, 0, LocalDate.now(), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
+            EducationAddress(4, mockEducation, Address("서울", "구로구", "123"), 9, 0, LocalDate.now(), TimeRange(LocalTime.of(12, 0), LocalTime.of(18, 0))),
+            EducationAddress(5, mockEducation, Address("서울", "송파구", "123"), 21, 0, LocalDate.of(2023, 12, 24), TimeRange(LocalTime.of(1, 0), LocalTime.of(23, 0))),
         )
 
         // when
@@ -56,11 +56,11 @@ class EducationAddressesTest {
         )
 
         val educationAddressList = mutableListOf(
-            EducationAddress(1, mockEducation, Address("서울", "관악구", "123"), 13, LocalDate.of(2023, 1, 27), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
-            EducationAddress(2, mockEducation, Address("서울", "강서구", "123"), 15, LocalDate.of(2023, 4, 19), TimeRange(LocalTime.of(13, 0), LocalTime.of(17, 0))),
-            EducationAddress(3, mockEducation, Address("서울", "강남구", "123"), 4, LocalDate.now(), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
-            EducationAddress(4, mockEducation, Address("서울", "강남구", "123"), 9, LocalDate.now(), TimeRange(LocalTime.of(9, 30), LocalTime.of(18, 0))),
-            EducationAddress(5, mockEducation, Address("서울", "송파구", "123"), 21, LocalDate.of(2023, 12, 24), TimeRange(LocalTime.of(1, 0), LocalTime.of(23, 0))),
+            EducationAddress(1, mockEducation, Address("서울", "관악구", "123"), 13, 0, LocalDate.of(2023, 1, 27), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
+            EducationAddress(2, mockEducation, Address("서울", "강서구", "123"), 15, 0, LocalDate.of(2023, 4, 19), TimeRange(LocalTime.of(13, 0), LocalTime.of(17, 0))),
+            EducationAddress(3, mockEducation, Address("서울", "강남구", "123"), 4, 0, LocalDate.now(), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
+            EducationAddress(4, mockEducation, Address("서울", "강남구", "123"), 9, 0, LocalDate.now(), TimeRange(LocalTime.of(9, 30), LocalTime.of(18, 0))),
+            EducationAddress(5, mockEducation, Address("서울", "송파구", "123"), 21, 0, LocalDate.of(2023, 12, 24), TimeRange(LocalTime.of(1, 0), LocalTime.of(23, 0))),
         )
 
         // when, then
@@ -83,12 +83,12 @@ class EducationAddressesTest {
         )
 
         val educationAddressList = mutableListOf(
-            EducationAddress(1, mockEducation, Address("서울", "관악구", "123"), 13, LocalDate.of(2023, 1, 27), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
-            EducationAddress(2, mockEducation, Address("서울", "강서구", "123"), 15, LocalDate.of(2023, 4, 19), TimeRange(LocalTime.of(13, 0), LocalTime.of(17, 0))),
-            EducationAddress(3, mockEducation, Address("서울", "강남구", "123"), 4, LocalDate.now(), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
-            EducationAddress(4, mockEducation, Address("서울", "구로구", "123"), 9, LocalDate.now(), TimeRange(LocalTime.of(12, 0), LocalTime.of(18, 0))),
-            EducationAddress(5, mockEducation, Address("서울", "송파구", "123"), 21, LocalDate.of(2023, 12, 24), TimeRange(LocalTime.of(1, 0), LocalTime.of(23, 0))),
-            EducationAddress(6, mockEducation, Address("서울", "서초구", "123"), 21, LocalDate.of(2023, 12, 25), TimeRange(LocalTime.of(9, 0), LocalTime.of(23, 0))),
+            EducationAddress(1, mockEducation, Address("서울", "관악구", "123"), 13, 0, LocalDate.of(2023, 1, 27), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
+            EducationAddress(2, mockEducation, Address("서울", "강서구", "123"), 15, 0, LocalDate.of(2023, 4, 19), TimeRange(LocalTime.of(13, 0), LocalTime.of(17, 0))),
+            EducationAddress(3, mockEducation, Address("서울", "강남구", "123"), 4, 0, LocalDate.now(), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
+            EducationAddress(4, mockEducation, Address("서울", "구로구", "123"), 9, 0, LocalDate.now(), TimeRange(LocalTime.of(12, 0), LocalTime.of(18, 0))),
+            EducationAddress(5, mockEducation, Address("서울", "송파구", "123"), 21, 0, LocalDate.of(2023, 12, 24), TimeRange(LocalTime.of(1, 0), LocalTime.of(23, 0))),
+            EducationAddress(6, mockEducation, Address("서울", "서초구", "123"), 21, 0, LocalDate.of(2023, 12, 25), TimeRange(LocalTime.of(9, 0), LocalTime.of(23, 0))),
         )
 
         // when, then
@@ -111,11 +111,11 @@ class EducationAddressesTest {
         )
 
         val educationAddressList = mutableListOf(
-            EducationAddress(1, mockEducation, Address("서울", "관악구", "123"), 13, LocalDate.of(2023, 1, 27), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
-            EducationAddress(2, mockEducation, Address("서울", "강서구", "123"), 15, LocalDate.of(2023, 4, 19), TimeRange(LocalTime.of(13, 0), LocalTime.of(17, 0))),
-            EducationAddress(3, mockEducation, Address("서울", "강남구", "123"), 4, LocalDate.now(), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
-            EducationAddress(4, mockEducation, Address("서울", "구로구", "123"), 9, LocalDate.now(), TimeRange(LocalTime.of(12, 0), LocalTime.of(18, 0))),
-            EducationAddress(5, mockEducation, Address("서울", "송파구", "123"), 21, LocalDate.of(2023, 12, 24), TimeRange(LocalTime.of(1, 0), LocalTime.of(23, 0))),
+            EducationAddress(1, mockEducation, Address("서울", "관악구", "123"), 13, 0, LocalDate.of(2023, 1, 27), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
+            EducationAddress(2, mockEducation, Address("서울", "강서구", "123"), 15, 0, LocalDate.of(2023, 4, 19), TimeRange(LocalTime.of(13, 0), LocalTime.of(17, 0))),
+            EducationAddress(3, mockEducation, Address("서울", "강남구", "123"), 4, 0, LocalDate.now(), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
+            EducationAddress(4, mockEducation, Address("서울", "구로구", "123"), 9, 0, LocalDate.now(), TimeRange(LocalTime.of(12, 0), LocalTime.of(18, 0))),
+            EducationAddress(5, mockEducation, Address("서울", "송파구", "123"), 21, 0, LocalDate.of(2023, 12, 24), TimeRange(LocalTime.of(1, 0), LocalTime.of(23, 0))),
         )
 
         val educationAddresses = EducationAddresses(educationAddressList)
@@ -140,14 +140,14 @@ class EducationAddressesTest {
         )
 
         val educationAddressList = mutableListOf(
-            EducationAddress(1, mockEducation, Address("서울", "관악구", "123"), 13, LocalDate.of(2023, 1, 27), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
-            EducationAddress(2, mockEducation, Address("서울", "강서구", "123"), 15, LocalDate.of(2023, 4, 19), TimeRange(LocalTime.of(13, 0), LocalTime.of(17, 0))),
-            EducationAddress(3, mockEducation, Address("서울", "강남구", "123"), 4, LocalDate.now(), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
-            EducationAddress(4, mockEducation, Address("서울", "구로구", "123"), 9, LocalDate.now(), TimeRange(LocalTime.of(12, 0), LocalTime.of(18, 0))),
-            EducationAddress(5, mockEducation, Address("서울", "송파구", "123"), 21, LocalDate.of(2023, 12, 24), TimeRange(LocalTime.of(10, 0), LocalTime.of(23, 0))),
+            EducationAddress(1, mockEducation, Address("서울", "관악구", "123"), 13, 0, LocalDate.of(2023, 1, 27), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
+            EducationAddress(2, mockEducation, Address("서울", "강서구", "123"), 15, 0, LocalDate.of(2023, 4, 19), TimeRange(LocalTime.of(13, 0), LocalTime.of(17, 0))),
+            EducationAddress(3, mockEducation, Address("서울", "강남구", "123"), 4, 0, LocalDate.now(), TimeRange(LocalTime.of(8, 0), LocalTime.of(11, 0))),
+            EducationAddress(4, mockEducation, Address("서울", "구로구", "123"), 9, 0, LocalDate.now(), TimeRange(LocalTime.of(12, 0), LocalTime.of(18, 0))),
+            EducationAddress(5, mockEducation, Address("서울", "송파구", "123"), 21, 0, LocalDate.of(2023, 12, 24), TimeRange(LocalTime.of(10, 0), LocalTime.of(23, 0))),
         )
 
-        val mockEducationAddress = EducationAddress(6, mockEducation, Address("서울", "송파구", "123"), 21, LocalDate.of(2023, 12, 24), TimeRange(LocalTime.of(1, 0), LocalTime.of(9, 0)))
+        val mockEducationAddress = EducationAddress(6, mockEducation, Address("서울", "송파구", "123"), 21, 0, LocalDate.of(2023, 12, 24), TimeRange(LocalTime.of(1, 0), LocalTime.of(9, 0)))
 
         val educationAddresses = EducationAddresses(educationAddressList)
 

--- a/mega-coffee-infra/database/mysql/build.gradle.kts
+++ b/mega-coffee-infra/database/mysql/build.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
     api("org.springframework.boot:spring-boot-starter")
     api("org.springframework.boot:spring-boot-starter-data-jpa")
 
+    // https://github.com/spring-projects/spring-retry
+    api("org.springframework.retry:spring-retry")
+
     implementation("com.querydsl:querydsl-jpa")
     kapt("com.querydsl:querydsl-apt:$querydslVersion:jpa")
 

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/config/RetryConfig.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/config/RetryConfig.kt
@@ -1,0 +1,24 @@
+package com.meloning.megaCoffee.infra.database.mysql.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.retry.annotation.EnableRetry
+import org.springframework.retry.support.RetryTemplate
+
+@Configuration
+@EnableRetry
+class RetryConfig {
+
+    @Bean
+    fun retryTemplate(): RetryTemplate {
+        return RetryTemplate.builder()
+            .fixedBackoff(BACK_OFF_INTERVAL)
+            .maxAttempts(MAX_ATTEMPTS)
+            .build()
+    }
+
+    companion object {
+        const val BACK_OFF_INTERVAL = 5000L // milliseconds
+        const val MAX_ATTEMPTS = 3
+    }
+}

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/education/entity/EducationAddressEntity.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/education/entity/EducationAddressEntity.kt
@@ -4,6 +4,7 @@ import com.meloning.megaCoffee.core.domain.education.model.EducationAddress
 import com.meloning.megaCoffee.infra.database.mysql.domain.common.AddressVO
 import com.meloning.megaCoffee.infra.database.mysql.domain.common.BaseTimeEntity
 import com.meloning.megaCoffee.infra.database.mysql.domain.common.TimeRangeVO
+import org.hibernate.annotations.ColumnDefault
 import org.hibernate.annotations.DynamicInsert
 import org.hibernate.annotations.DynamicUpdate
 import org.hibernate.proxy.HibernateProxy
@@ -18,6 +19,7 @@ import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.Table
+import javax.persistence.Version
 
 @Entity
 @Table(name = "education_address")
@@ -25,10 +27,11 @@ import javax.persistence.Table
 @DynamicUpdate
 class EducationAddressEntity : BaseTimeEntity {
 
-    constructor(id: Long?, education: EducationEntity, address: AddressVO, maxParticipant: Int, date: LocalDate, timeRange: TimeRangeVO) : super() {
+    constructor(id: Long?, education: EducationEntity, address: AddressVO, currentParticipant: Int, maxParticipant: Int, date: LocalDate, timeRange: TimeRangeVO) : super() {
         this.id = id
         this.education = education
         this.address = address
+        this.currentParticipant = currentParticipant
         this.maxParticipant = maxParticipant
         this.date = date
         this.timeRange = timeRange
@@ -52,6 +55,11 @@ class EducationAddressEntity : BaseTimeEntity {
         protected set
 
     @Column(nullable = false)
+    @ColumnDefault("0")
+    var currentParticipant: Int = 0
+        protected set
+
+    @Column(nullable = false)
     var date: LocalDate
         protected set
 
@@ -59,10 +67,15 @@ class EducationAddressEntity : BaseTimeEntity {
     var timeRange: TimeRangeVO
         protected set
 
+    @Version
+    @ColumnDefault("0")
+    var version: Long = 0
+
     fun toModel() = EducationAddress(
         id = id,
         education = education.toModel(),
         address = address.toModel(),
+        currentParticipant = currentParticipant,
         maxParticipant = maxParticipant,
         date = date,
         timeRange = timeRange.toModel(),
@@ -77,6 +90,7 @@ class EducationAddressEntity : BaseTimeEntity {
                 id = id,
                 education = EducationEntity.from(education),
                 address = AddressVO.from(address),
+                currentParticipant = currentParticipant,
                 maxParticipant = maxParticipant,
                 date = date,
                 timeRange = TimeRangeVO.from(timeRange)

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/education/repository/CustomEducationJpaRepository.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/education/repository/CustomEducationJpaRepository.kt
@@ -6,5 +6,4 @@ import com.meloning.megaCoffee.infra.database.mysql.domain.education.entity.Educ
 interface CustomEducationJpaRepository {
     fun findAllByStoreIdAndUserId(storeId: Long, userId: Long): Pair<List<EducationEntity>, List<EducationAddressEntity>>
     fun findAllByStoreId(storeId: Long): List<EducationEntity>
-    fun countByEducationAddressId(educationAddressId: Long): Int
 }

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/education/repository/CustomEducationJpaRepositoryImpl.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/education/repository/CustomEducationJpaRepositoryImpl.kt
@@ -20,13 +20,6 @@ class CustomEducationJpaRepositoryImpl(
     private val qStoreEducationRelationEntity = QStoreEducationRelationEntity.storeEducationRelationEntity
     private val qUserEducationAddressRelationEntity = QUserEducationAddressRelationEntity.userEducationAddressRelationEntity
 
-    override fun countByEducationAddressId(educationAddressId: Long): Int {
-        return jpaQueryFactory.selectFrom(qUserEducationAddressRelationEntity)
-            .where(qUserEducationAddressRelationEntity.educationAddressId.eq(educationAddressId))
-            .fetch()
-            .size
-    }
-
     override fun findAllByStoreIdAndUserId(storeId: Long, userId: Long): Pair<List<EducationEntity>, List<EducationAddressEntity>> {
         val educations = jpaQueryFactory.selectFrom(qEducationEntity)
             .join(qStoreEducationRelationEntity)

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/education/repository/EducationRepositoryImpl.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/education/repository/EducationRepositoryImpl.kt
@@ -78,8 +78,4 @@ class EducationRepositoryImpl(
     override fun deleteById(id: Long) {
         educationJpaRepository.deleteById(id)
     }
-
-    override fun countByEducationAddressId(educationAddressId: Long): Int {
-        return educationJpaRepository.countByEducationAddressId(educationAddressId)
-    }
 }

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/entity/UserEducationAddressRelationEntity.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/entity/UserEducationAddressRelationEntity.kt
@@ -50,16 +50,21 @@ class UserEducationAddressRelationEntity : CreatedAtEntity {
         }
     }
 
-    final override fun equals(other: Any?): Boolean {
+    override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other == null) return false
-        val oEffectiveClass = if (other is HibernateProxy) other.hibernateLazyInitializer.persistentClass else other.javaClass
-        val thisEffectiveClass = if (this is HibernateProxy) this.hibernateLazyInitializer.persistentClass else this.javaClass
-        if (thisEffectiveClass != oEffectiveClass) return false
+        if (javaClass != other?.javaClass) return false
+
         other as UserEducationAddressRelationEntity
 
-        return id != null && id == other.id
+        if (user != other.user) return false
+        if (educationAddressId != other.educationAddressId) return false
+
+        return true
     }
 
-    final override fun hashCode(): Int = id.hashCode()
+    override fun hashCode(): Int {
+        var result = user.hashCode()
+        result = 31 * result + educationAddressId.hashCode()
+        return result
+    }
 }

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/entity/UserEntity.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/entity/UserEntity.kt
@@ -78,10 +78,10 @@ class UserEntity : BaseTimeEntity {
         protected set
 
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
-    var educationAddressRelations: MutableList<UserEducationAddressRelationEntity> = mutableListOf()
+    var educationAddressRelations: MutableSet<UserEducationAddressRelationEntity> = mutableSetOf()
         protected set
 
-    fun update(educationAddresses: MutableList<UserEducationAddressRelationEntity>) {
+    fun update(educationAddresses: MutableSet<UserEducationAddressRelationEntity>) {
         this.educationAddressRelations = educationAddresses
     }
 

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/lock/RegisterEducationAddressFacadeServiceImpl.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/lock/RegisterEducationAddressFacadeServiceImpl.kt
@@ -1,0 +1,33 @@
+package com.meloning.megaCoffee.infra.database.mysql.domain.user.lock
+
+import com.meloning.megaCoffee.common.error.exception.RetryFailedException
+import com.meloning.megaCoffee.core.domain.user.usecase.RegisterEducationAddressFacadeService
+import com.meloning.megaCoffee.core.domain.user.usecase.UserService
+import com.meloning.megaCoffee.core.domain.user.usecase.command.RegisterEducationAddressCommand
+import org.springframework.orm.ObjectOptimisticLockingFailureException
+import org.springframework.retry.RecoveryCallback
+import org.springframework.retry.RetryCallback
+import org.springframework.retry.support.RetryTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class RegisterEducationAddressFacadeServiceImpl(
+    private val userService: UserService,
+    private val retryTemplate: RetryTemplate
+) : RegisterEducationAddressFacadeService {
+
+    override fun execute(id: Long, command: RegisterEducationAddressCommand) {
+        try {
+            userService.registerEducationAddress(id, command)
+        } catch (e: ObjectOptimisticLockingFailureException) {
+            retryTemplate.execute(
+                RetryCallback<Unit, Exception> {
+                    userService.registerEducationAddress(id, command)
+                },
+                RecoveryCallback {
+                    throw RetryFailedException("OptimisticLock 발생에 대한 Retry 처리를 실패하였습니다.", e)
+                }
+            )
+        }
+    }
+}

--- a/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/repository/UserRepositoryImpl.kt
+++ b/mega-coffee-infra/database/mysql/src/main/kotlin/com/meloning/megaCoffee/infra/database/mysql/domain/user/repository/UserRepositoryImpl.kt
@@ -28,7 +28,7 @@ class UserRepositoryImpl(
     override fun update(user: User) {
         userJpaRepository.save(
             UserEntity.from(user).apply {
-                update(user.educationAddressRelations.map { UserEducationAddressRelationEntity.from(it) }.toMutableList())
+                update(user.educationAddressRelations.map { UserEducationAddressRelationEntity.from(it) }.toMutableSet())
             }
         )
     }
@@ -48,7 +48,7 @@ class UserRepositoryImpl(
             Hibernate.initialize(it)
         }
         return userEntity?.toModel()?.apply {
-            update(userEntity.educationAddressRelations.map { it.toModel() }.toMutableList())
+            update(userEntity.educationAddressRelations.map { it.toModel() }.toMutableSet())
         }
     }
 

--- a/mega-coffee-infra/database/mysql/src/main/resources/data.sql
+++ b/mega-coffee-infra/database/mysql/src/main/resources/data.sql
@@ -127,74 +127,74 @@ VALUES
 
 -- 교육프로그램별 교육 장소
 -- 교육 프로그램 1 - 커피 추출과 조리 기초 교육
-INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, max_participant, end_time, start_time, education_id)
+INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, current_participant, max_participant, end_time, start_time, education_id)
 VALUES
-    (1, CURRENT_TIMESTAMP(6), NULL, '서울', '강남구 테헤란로 123번길', '06132', '2023-08-15', 2, '17:00:00', '14:00:00', 1),
-    (2, CURRENT_TIMESTAMP(6), NULL, '서울', '서초구 반포대로 456번길', '06577', '2023-08-16', 3, '17:00:00', '14:00:00', 1),
-    (3, CURRENT_TIMESTAMP(6), NULL, '인천', '남동구 성리로 789번길', '21536', '2023-08-17', 5, '17:00:00', '14:00:00', 1);
+    (1, CURRENT_TIMESTAMP(6), NULL, '서울', '강남구 테헤란로 123번길', '06132', '2023-08-15', 0, 2, '17:00:00', '14:00:00', 1),
+    (2, CURRENT_TIMESTAMP(6), NULL, '서울', '서초구 반포대로 456번길', '06577', '2023-08-16', 0, 3, '17:00:00', '14:00:00', 1),
+    (3, CURRENT_TIMESTAMP(6), NULL, '인천', '남동구 성리로 789번길', '21536', '2023-08-17', 0, 5, '17:00:00', '14:00:00', 1);
 
 -- 교육 프로그램 2 - 커피 음료와 레시피 교육
-INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, max_participant, end_time, start_time, education_id)
+INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, current_participant, max_participant, end_time, start_time, education_id)
 VALUES
-    (4, CURRENT_TIMESTAMP(6), NULL, '부산', '해운대구 해운대로 111번길', '48100', '2023-08-15', 3, '18:00:00', '15:00:00', 2),
-    (5, CURRENT_TIMESTAMP(6), NULL, '부산', '사하구 하단로 222번길', '49494', '2023-08-16', 5, '18:00:00', '15:00:00', 2),
-    (6, CURRENT_TIMESTAMP(6), NULL, '대구', '수성구 중동로 333번길', '42185', '2023-08-17', 7, '18:00:00', '15:00:00', 2);
+    (4, CURRENT_TIMESTAMP(6), NULL, '부산', '해운대구 해운대로 111번길', '48100', '2023-08-15', 0, 3, '18:00:00', '15:00:00', 2),
+    (5, CURRENT_TIMESTAMP(6), NULL, '부산', '사하구 하단로 222번길', '49494', '2023-08-16', 0, 5, '18:00:00', '15:00:00', 2),
+    (6, CURRENT_TIMESTAMP(6), NULL, '대구', '수성구 중동로 333번길', '42185', '2023-08-17', 0, 7, '18:00:00', '15:00:00', 2);
 
 -- 교육 프로그램 3 - 커피 맛 평가 교육
-INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, max_participant, end_time, start_time, education_id)
+INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, current_participant, max_participant, end_time, start_time, education_id)
 VALUES
-    (7, CURRENT_TIMESTAMP(6), NULL, '경기', '성남시 분당구 성남대로 444번길', '13489', '2023-08-15', 2, '16:00:00', '13:00:00', 3),
-    (8, CURRENT_TIMESTAMP(6), NULL, '경기', '고양시 일산동구 일산로 555번길', '10452', '2023-08-16', 5, '16:00:00', '13:00:00', 3),
-    (9, CURRENT_TIMESTAMP(6), NULL, '서울', '양천구 목동중앙북로 666번길', '08081', '2023-08-17', 3, '16:00:00', '13:00:00', 3);
+    (7, CURRENT_TIMESTAMP(6), NULL, '경기', '성남시 분당구 성남대로 444번길', '13489', '2023-08-15', 0, 2, '16:00:00', '13:00:00', 3),
+    (8, CURRENT_TIMESTAMP(6), NULL, '경기', '고양시 일산동구 일산로 555번길', '10452', '2023-08-16', 0, 5, '16:00:00', '13:00:00', 3),
+    (9, CURRENT_TIMESTAMP(6), NULL, '서울', '양천구 목동중앙북로 666번길', '08081', '2023-08-17', 0, 3, '16:00:00', '13:00:00', 3);
 
 -- 교육 프로그램 4 - 고객 상담 및 서비스 교육
-INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, max_participant, end_time, start_time, education_id)
+INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, current_participant, max_participant, end_time, start_time, education_id)
 VALUES
-    (10, CURRENT_TIMESTAMP(6), NULL, '서울', '강동구 천호대로 777번길', '05364', '2023-08-15', 30, '17:00:00', '14:00:00', 4),
-    (11, CURRENT_TIMESTAMP(6), NULL, '서울', '관악구 관악로 888번길', '08776', '2023-08-16', 15, '17:00:00', '14:00:00', 4),
-    (12, CURRENT_TIMESTAMP(6), NULL, '경기', '성남시 수정구 수정로 999번길', '13485', '2023-08-17', 20, '17:00:00', '14:00:00', 4);
+    (10, CURRENT_TIMESTAMP(6), NULL, '서울', '강동구 천호대로 777번길', '05364', '2023-08-15', 0, 30, '17:00:00', '14:00:00', 4),
+    (11, CURRENT_TIMESTAMP(6), NULL, '서울', '관악구 관악로 888번길', '08776', '2023-08-16', 0, 15, '17:00:00', '14:00:00', 4),
+    (12, CURRENT_TIMESTAMP(6), NULL, '경기', '성남시 수정구 수정로 999번길', '13485', '2023-08-17', 0, 20, '17:00:00', '14:00:00', 4);
 
 -- 교육 프로그램 5 - 커피 원두 관리 교육
-INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, max_participant, end_time, start_time, education_id)
+INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, current_participant, max_participant, end_time, start_time, education_id)
 VALUES
-    (13, CURRENT_TIMESTAMP(6), NULL, '인천', '남동구 인주대로 1010번길', '21546', '2023-08-15', 5, '18:00:00', '15:00:00', 5),
-    (14, CURRENT_TIMESTAMP(6), NULL, '인천', '연수구 연수로 1111번길', '22004', '2023-08-16', 15, '18:00:00', '15:00:00', 5),
-    (15, CURRENT_TIMESTAMP(6), NULL, '대구', '수성구 고산로 1212번길', '42178', '2023-08-17', 25, '18:00:00', '15:00:00', 5);
+    (13, CURRENT_TIMESTAMP(6), NULL, '인천', '남동구 인주대로 1010번길', '21546', '2023-08-15', 0, 5, '18:00:00', '15:00:00', 5),
+    (14, CURRENT_TIMESTAMP(6), NULL, '인천', '연수구 연수로 1111번길', '22004', '2023-08-16', 0, 15, '18:00:00', '15:00:00', 5),
+    (15, CURRENT_TIMESTAMP(6), NULL, '대구', '수성구 고산로 1212번길', '42178', '2023-08-17', 0, 25, '18:00:00', '15:00:00', 5);
 
 -- 교육 프로그램 6 - 디저트와 커피 매칭 교육
-INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, max_participant, end_time, start_time, education_id)
+INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, current_participant, max_participant, end_time, start_time, education_id)
 VALUES
-    (16, CURRENT_TIMESTAMP(6), NULL, '경기', '성남시 중원구 중앙로 1313번길', '13585', '2023-08-15', 10, '16:00:00', '13:00:00', 6),
-    (17, CURRENT_TIMESTAMP(6), NULL, '경기', '고양시 덕양구 고양대로 1414번길', '10522', '2023-08-16', 20, '16:00:00', '13:00:00', 6),
-    (18, CURRENT_TIMESTAMP(6), NULL, '서울', '영등포구 여의나루로 1515번길', '07311', '2023-08-17', 4, '16:00:00', '13:00:00', 6);
+    (16, CURRENT_TIMESTAMP(6), NULL, '경기', '성남시 중원구 중앙로 1313번길', '13585', '2023-08-15', 0, 10, '16:00:00', '13:00:00', 6),
+    (17, CURRENT_TIMESTAMP(6), NULL, '경기', '고양시 덕양구 고양대로 1414번길', '10522', '2023-08-16', 0, 20, '16:00:00', '13:00:00', 6),
+    (18, CURRENT_TIMESTAMP(6), NULL, '서울', '영등포구 여의나루로 1515번길', '07311', '2023-08-17', 0, 4, '16:00:00', '13:00:00', 6);
 
 -- 교육 프로그램 7 - 스페셜티 커피와 라떼아트 교육
-INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, max_participant, end_time, start_time, education_id)
+INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, current_participant, max_participant, end_time, start_time, education_id)
 VALUES
-    (19, CURRENT_TIMESTAMP(6), NULL, '부산', '남구 암남로 1616번길', '48563', '2023-08-15', 5, '19:00:00', '16:00:00', 7),
-    (20, CURRENT_TIMESTAMP(6), NULL, '부산', '기장군 기장읍 기장대로 1717번길', '46020', '2023-08-16', 5, '19:00:00', '16:00:00', 7),
-    (21, CURRENT_TIMESTAMP(6), NULL, '대구', '달성군 다사읍 성서로 1818번길', '42926', '2023-08-17', 5, '19:00:00', '16:00:00', 7);
+    (19, CURRENT_TIMESTAMP(6), NULL, '부산', '남구 암남로 1616번길', '48563', '2023-08-15', 0, 5, '19:00:00', '16:00:00', 7),
+    (20, CURRENT_TIMESTAMP(6), NULL, '부산', '기장군 기장읍 기장대로 1717번길', '46020', '2023-08-16', 0, 5, '19:00:00', '16:00:00', 7),
+    (21, CURRENT_TIMESTAMP(6), NULL, '대구', '달성군 다사읍 성서로 1818번길', '42926', '2023-08-17', 0, 5, '19:00:00', '16:00:00', 7);
 
 -- 교육 프로그램 8 - 커피 블렌딩과 로스팅 교육
-INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, max_participant, end_time, start_time, education_id)
+INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, current_participant, max_participant, end_time, start_time, education_id)
 VALUES
-    (22, CURRENT_TIMESTAMP(6), NULL, '서울', '서대문구 연세로 2020번길', '03722', '2023-08-15', 3, '17:00:00', '14:00:00', 8),
-    (23, CURRENT_TIMESTAMP(6), NULL, '서울', '마포구 와우산로 2121번길', '04011', '2023-08-16', 3, '17:00:00', '14:00:00', 8),
-    (24, CURRENT_TIMESTAMP(6), NULL, '인천', '연수구 연수로 2222번길', '22004', '2023-08-17', 3, '17:00:00', '14:00:00', 8);
+    (22, CURRENT_TIMESTAMP(6), NULL, '서울', '서대문구 연세로 2020번길', '03722', '2023-08-15', 0, 3, '17:00:00', '14:00:00', 8),
+    (23, CURRENT_TIMESTAMP(6), NULL, '서울', '마포구 와우산로 2121번길', '04011', '2023-08-16', 0, 3, '17:00:00', '14:00:00', 8),
+    (24, CURRENT_TIMESTAMP(6), NULL, '인천', '연수구 연수로 2222번길', '22004', '2023-08-17', 0, 3, '17:00:00', '14:00:00', 8);
 
 -- 교육 프로그램 9 - 커피 장비 사용 교육
-INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, max_participant, end_time, start_time, education_id)
+INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, current_participant, max_participant, end_time, start_time, education_id)
 VALUES
-    (25, CURRENT_TIMESTAMP(6), NULL, '부산', '서구 보수대로 2323번길', '49108', '2023-08-15', 2, '18:00:00', '15:00:00', 9),
-    (26, CURRENT_TIMESTAMP(6), NULL, '부산', '동래구 온천장로 2424번길', '47891', '2023-08-16', 2, '18:00:00', '15:00:00', 9),
-    (27, CURRENT_TIMESTAMP(6), NULL, '대구', '달서구 달구벌대로 2525번길', '42702', '2023-08-17', 2, '18:00:00', '15:00:00', 9);
+    (25, CURRENT_TIMESTAMP(6), NULL, '부산', '서구 보수대로 2323번길', '49108', '2023-08-15', 0, 2, '18:00:00', '15:00:00', 9),
+    (26, CURRENT_TIMESTAMP(6), NULL, '부산', '동래구 온천장로 2424번길', '47891', '2023-08-16', 0, 2, '18:00:00', '15:00:00', 9),
+    (27, CURRENT_TIMESTAMP(6), NULL, '대구', '달서구 달구벌대로 2525번길', '42702', '2023-08-17', 0, 2, '18:00:00', '15:00:00', 9);
 
 -- 교육 프로그램 10 - 매장 운영과 관리 교육
-INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, max_participant, end_time, start_time, education_id)
+INSERT INTO education_address (id, created_at, updated_at, city, street, zip_code, date, current_participant, max_participant, end_time, start_time, education_id)
 VALUES
-    (28, CURRENT_TIMESTAMP(6), NULL, '경기', '용인시 기흥구 용구대로 2626번길', '16977', '2023-08-15', 7, '16:00:00', '13:00:00', 10),
-    (29, CURRENT_TIMESTAMP(6), NULL, '경기', '성남시 분당구 서현로 2727번길', '13623', '2023-08-16', 8, '16:00:00', '13:00:00', 10),
-    (30, CURRENT_TIMESTAMP(6), NULL, '서울', '강서구 화곡로 2828번길', '07679', '2023-08-17', 9, '16:00:00', '13:00:00', 10);
+    (28, CURRENT_TIMESTAMP(6), NULL, '경기', '용인시 기흥구 용구대로 2626번길', '16977', '2023-08-15', 0, 7, '16:00:00', '13:00:00', 10),
+    (29, CURRENT_TIMESTAMP(6), NULL, '경기', '성남시 분당구 서현로 2727번길', '13623', '2023-08-16', 0, 8, '16:00:00', '13:00:00', 10),
+    (30, CURRENT_TIMESTAMP(6), NULL, '서울', '강서구 화곡로 2828번길', '07679', '2023-08-17', 0, 9, '16:00:00', '13:00:00', 10);
 
 -- 매장에서 들어야할 교육 프로그램 데이터
 INSERT INTO store_education_relation(id, created_at, education_id, store_id)


### PR DESCRIPTION
Related: #5 

- 동시성 테스트 코드 작성
- 로깅 항목 추가
- 교육장소 모델에 현재 참여자수 필드 및 낙관적 락적용을 위한 version 필드 추가
- count querydsl 로직 삭제
- 낙관적 락 발생시 재시도 매커니즘 구현을 위해 Retry 라이브러리 추가 및 `retryTemplate` 설정